### PR TITLE
Add stray headers to module

### DIFF
--- a/Modules/module.modulemap
+++ b/Modules/module.modulemap
@@ -7,6 +7,10 @@ framework module MIQTestingFramework {
     explicit module ExpectaHelpers {
         header "EXPDoubleTuple.h"
         header "EXPFloatTuple.h"
+        header "EXPBackwardCompatibility.h"
+        header "EXPMatcherHelpers.h"
+        header "EXPUnsupportedObject.h"
+        header "NSValue+Expecta.h"
         export *
     }
 }


### PR DESCRIPTION
Modules get upset if there's unreachable headers, which I keep forgetting. Apologies...
